### PR TITLE
feat: refactor storage interface

### DIFF
--- a/p2p/discover/api.go
+++ b/p2p/discover/api.go
@@ -476,7 +476,7 @@ func (p *PortalProtocolAPI) LocalContent(contentKeyHex string) (string, error) {
 		return "", err
 	}
 	contentId := p.portalProtocol.ToContentId(contentKey)
-	content, err := p.portalProtocol.Get(contentId)
+	content, err := p.portalProtocol.Get(contentKey, contentId)
 
 	if err != nil {
 		return "", err
@@ -497,7 +497,7 @@ func (p *PortalProtocolAPI) Store(contentKeyHex string, contextHex string) (bool
 	if err != nil {
 		return false, err
 	}
-	err = p.portalProtocol.Put(contentId, content)
+	err = p.portalProtocol.Put(contentKey, contentId, content)
 	if err != nil {
 		return false, err
 	}

--- a/p2p/discover/portal_protocol_test.go
+++ b/p2p/discover/portal_protocol_test.go
@@ -27,14 +27,14 @@ type MockStorage struct {
 	db map[string][]byte
 }
 
-func (m *MockStorage) Get(contentId []byte) ([]byte, error) {
+func (m *MockStorage) Get(contentKey []byte, contentId []byte) ([]byte, error) {
 	if content, ok := m.db[string(contentId)]; ok {
 		return content, nil
 	}
 	return nil, ContentNotFound
 }
 
-func (m *MockStorage) Put(contentId []byte, content []byte) error {
+func (m *MockStorage) Put(contentKey []byte, contentId []byte, content []byte) error {
 	m.db[string(contentId)] = content
 	return nil
 }
@@ -304,7 +304,7 @@ func TestPortalWireProtocol(t *testing.T) {
 		return n.ID() == node2.localNode.Node().ID()
 	})
 
-	err = node1.storage.Put(node1.toContentId([]byte("test_key")), []byte("test_value"))
+	err = node1.storage.Put(nil, node1.toContentId([]byte("test_key")), []byte("test_value"))
 	assert.NoError(t, err)
 
 	flag, content, err := node2.findContent(node1.localNode.Node(), []byte("test_key"))
@@ -324,7 +324,7 @@ func TestPortalWireProtocol(t *testing.T) {
 	_, err = rand.Read(largeTestContent)
 	assert.NoError(t, err)
 
-	err = node1.storage.Put(node1.toContentId([]byte("large_test_key")), largeTestContent)
+	err = node1.storage.Put(nil, node1.toContentId([]byte("large_test_key")), largeTestContent)
 	assert.NoError(t, err)
 
 	flag, content, err = node2.findContent(node1.localNode.Node(), []byte("large_test_key"))
@@ -452,7 +452,7 @@ func TestContentLookup(t *testing.T) {
 	content := []byte{0x1, 0x2}
 	contentId := node1.toContentId(contentKey)
 
-	err = node3.storage.Put(contentId, content)
+	err = node3.storage.Put(nil, contentId, content)
 	assert.NoError(t, err)
 
 	res, _, err := node1.ContentLookup(contentKey)
@@ -487,7 +487,7 @@ func TestTraceContentLookup(t *testing.T) {
 	content := []byte{0x1, 0x2}
 	contentId := node1.toContentId(contentKey)
 
-	err = node1.storage.Put(contentId, content)
+	err = node1.storage.Put(nil, contentId, content)
 	assert.NoError(t, err)
 
 	node1Id := hexutil.Encode(node1.Self().ID().Bytes())

--- a/portalnetwork/history/history_network_test.go
+++ b/portalnetwork/history/history_network_test.go
@@ -206,7 +206,7 @@ func TestGetContentByKey(t *testing.T) {
 	require.Nil(t, header)
 
 	contentId := historyNetwork1.portalProtocol.ToContentId(headerEntry.key)
-	err = historyNetwork1.portalProtocol.Put(contentId, headerEntry.value)
+	err = historyNetwork1.portalProtocol.Put(headerEntry.key, contentId, headerEntry.value)
 	require.NoError(t, err)
 	// get content from historyNetwork1
 	header, err = historyNetwork2.GetBlockHeader(headerEntry.key[1:])
@@ -225,7 +225,7 @@ func TestGetContentByKey(t *testing.T) {
 	require.Nil(t, body)
 
 	contentId = historyNetwork1.portalProtocol.ToContentId(bodyEntry.key)
-	err = historyNetwork1.portalProtocol.Put(contentId, bodyEntry.value)
+	err = historyNetwork1.portalProtocol.Put(bodyEntry.key, contentId, bodyEntry.value)
 	require.NoError(t, err)
 	// get content from historyNetwork1
 	body, err = historyNetwork2.GetBlockBody(bodyEntry.key[1:])
@@ -244,7 +244,7 @@ func TestGetContentByKey(t *testing.T) {
 	require.Nil(t, receipts)
 
 	contentId = historyNetwork1.portalProtocol.ToContentId(receiptsEntry.key)
-	err = historyNetwork1.portalProtocol.Put(contentId, receiptsEntry.value)
+	err = historyNetwork1.portalProtocol.Put(receiptsEntry.key, contentId, receiptsEntry.value)
 	require.NoError(t, err)
 	// get content from historyNetwork1
 	receipts, err = historyNetwork2.GetReceipts(receiptsEntry.key[1:])
@@ -276,7 +276,7 @@ func TestGetContentByKey(t *testing.T) {
 	require.Nil(t, epoch)
 
 	contentId = historyNetwork1.portalProtocol.ToContentId(contentKey)
-	err = historyNetwork1.portalProtocol.Put(contentId, content)
+	err = historyNetwork1.portalProtocol.Put(contentKey, contentId, content)
 	require.NoError(t, err)
 	// get content from historyNetwork1
 	epoch, err = historyNetwork2.GetEpochAccumulator(contentKey[1:])
@@ -366,14 +366,14 @@ type MockStorage struct {
 	db map[string][]byte
 }
 
-func (m *MockStorage) Get(contentId []byte) ([]byte, error) {
+func (m *MockStorage) Get(contentKey []byte, contentId []byte) ([]byte, error) {
 	if content, ok := m.db[string(contentId)]; ok {
 		return content, nil
 	}
 	return nil, storage.ErrContentNotFound
 }
 
-func (m *MockStorage) Put(contentId []byte, content []byte) error {
+func (m *MockStorage) Put(contentKey []byte, contentId []byte, content []byte) error {
 	m.db[string(contentId)] = content
 	return nil
 }

--- a/portalnetwork/storage/content_storage.go
+++ b/portalnetwork/storage/content_storage.go
@@ -5,7 +5,7 @@ import "fmt"
 var ErrContentNotFound = fmt.Errorf("content not found")
 
 type ContentStorage interface {
-	Get(contentId []byte) ([]byte, error)
+	Get(contentKey []byte, contentId []byte) ([]byte, error)
 
-	Put(contentId []byte, content []byte) error
+	Put(contentKey []byte, contentId []byte, content []byte) error
 }

--- a/portalnetwork/storage/sqlite/content_storage.go
+++ b/portalnetwork/storage/sqlite/content_storage.go
@@ -145,7 +145,7 @@ func createDir(dir string) error {
 }
 
 // Get the content according to the contentId
-func (p *ContentStorage) Get(contentId []byte) ([]byte, error) {
+func (p *ContentStorage) Get(contentKey []byte, contentId []byte) ([]byte, error) {
 	var res []byte
 	err := p.getStmt.QueryRow(contentId).Scan(&res)
 	if err == sql.ErrNoRows {
@@ -178,7 +178,7 @@ func newPutResultWithErr(err error) PutResult {
 	}
 }
 
-func (p *ContentStorage) Put(contentId []byte, content []byte) error {
+func (p *ContentStorage) Put(contentKey []byte, contentId []byte, content []byte) error {
 	res := p.put(contentId, content)
 	return res.Err()
 }

--- a/portalnetwork/storage/sqlite/content_storage_test.go
+++ b/portalnetwork/storage/sqlite/content_storage_test.go
@@ -36,13 +36,13 @@ func TestBasicStorage(t *testing.T) {
 	contentId := []byte("test")
 	content := []byte("value")
 
-	_, err = storage.Get(contentId)
+	_, err = storage.Get(nil, contentId)
 	assert.Equal(t, contentStorage.ErrContentNotFound, err)
 
 	pt := storage.put(contentId, content)
 	assert.NoError(t, pt.Err())
 
-	val, err := storage.Get(contentId)
+	val, err := storage.Get(nil, contentId)
 	assert.NoError(t, err)
 	assert.Equal(t, content, val)
 
@@ -177,13 +177,13 @@ func TestDBPruning(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, usedSize < storage.storageCapacityInBytes)
 
-	_, err = storage.Get(furthestElement.Bytes())
+	_, err = storage.Get(nil, furthestElement.Bytes())
 	assert.Equal(t, contentStorage.ErrContentNotFound, err)
 
-	_, err = storage.Get(secondFurthest.Bytes())
+	_, err = storage.Get(nil, secondFurthest.Bytes())
 	assert.Equal(t, contentStorage.ErrContentNotFound, err)
 
-	val, err := storage.Get(thirdFurthest.Bytes())
+	val, err := storage.Get(nil, thirdFurthest.Bytes())
 	assert.NoError(t, err)
 	assert.NotNil(t, val)
 }
@@ -203,7 +203,7 @@ func TestGetLargestDistance(t *testing.T) {
 	pt7 := storage.put(furthestElement.Bytes(), genBytes(2000))
 	assert.NoError(t, pt7.Err())
 
-	val, err := storage.Get(furthestElement.Bytes())
+	val, err := storage.Get(nil, furthestElement.Bytes())
 	assert.NoError(t, err)
 	assert.NotNil(t, val)
 	pt8 := storage.put(secondFurthest.Bytes(), genBytes(2000))
@@ -241,13 +241,13 @@ func TestSimpleForcePruning(t *testing.T) {
 	err = storage.ForcePrune(uint256.NewInt(20))
 	assert.NoError(t, err)
 
-	_, err = storage.Get(furthestElement.Bytes())
+	_, err = storage.Get(nil, furthestElement.Bytes())
 	assert.Equal(t, contentStorage.ErrContentNotFound, err)
 
-	_, err = storage.Get(secondFurthest.Bytes())
+	_, err = storage.Get(nil, secondFurthest.Bytes())
 	assert.Equal(t, contentStorage.ErrContentNotFound, err)
 
-	_, err = storage.Get(third.Bytes())
+	_, err = storage.Get(nil, third.Bytes())
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
fixes #62 

1. refactor storage interface
2. add some err log in history network
3. use contentId in ContentLookup and TraceContentLookup method