### PR TITLE
Save/load private key to file "clientKey"

### DIFF
--- a/cmd/shisui/config_test.go
+++ b/cmd/shisui/config_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"flag"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
@@ -13,7 +16,8 @@ func TestGenConfig(t *testing.T) {
 	flagSet := flag.NewFlagSet("test", 0)
 	flagSet.String("rpc.addr", "127.0.0.11", "test")
 	flagSet.String("rpc.port", "8888", "test")
-	flagSet.String("data.dir", "./test", "test")
+	tmpDir := t.TempDir()
+	flagSet.String("data.dir", tmpDir, "test")
 	flagSet.Uint64("data.capacity", size, "test")
 	// flagSet.String("udp.addr", "172.23.50.11", "test")
 	flagSet.Int("udp.port", 9999, "test")
@@ -30,9 +34,37 @@ func TestGenConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, config.DataCapacity, size)
-	require.Equal(t, config.DataDir, "./test")
+	require.Equal(t, config.DataDir, tmpDir)
 	require.Equal(t, config.LogLevel, 3)
 	// require.Equal(t, config.RpcAddr, "127.0.0.11:8888")
 	require.Equal(t, config.Protocol.ListenAddr, ":9999")
 	require.Equal(t, config.Networks, []string{"history"})
+}
+
+func TestKeyConfig(t *testing.T) {
+	flagSet := flag.NewFlagSet("test", 0)
+	tmpDir := t.TempDir()
+	flagSet.String("data.dir", tmpDir, "test")
+	pk := "a19d7a264e68004832327fca0ac46636332e0ec4b2a20a7ac942020754fcb666"
+	flagSet.String("private.key", "0x"+pk, "test")
+
+	command := &cli.Command{Name: "mycommand"}
+
+	ctx := cli.NewContext(nil, flagSet, nil)
+	ctx.Command = command
+
+	config, err := getPortalConfig(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, config.DataDir, tmpDir)
+
+	keyPk, err := crypto.HexToECDSA(pk)
+	require.Nil(t, err)
+	require.Equal(t, config.PrivateKey, keyPk)
+
+	fullPath := filepath.Join(config.DataDir, privateKeyFileName)
+	keyStored, err := os.ReadFile(fullPath)
+	require.Nil(t, err)
+	keyEnc := string(keyStored)
+	require.Equal(t, keyEnc, pk)
 }

--- a/cmd/shisui/main.go
+++ b/cmd/shisui/main.go
@@ -433,7 +433,7 @@ func setPrivateKey(ctx *cli.Context, config *Config) error {
 			}
 		}
 	}
-	log.Debug("Current client private key", "private key", privateKey)
+
 	config.PrivateKey = privateKey
 	err = writePrivateKey(privateKey, config, privateKeyFileName)
 	if err != nil {

--- a/cmd/shisui/main.go
+++ b/cmd/shisui/main.go
@@ -446,7 +446,7 @@ func writePrivateKey(privateKey *ecdsa.PrivateKey, config *Config, fileName stri
 	keyEnc := hex.EncodeToString(crypto.FromECDSA(privateKey))
 
 	fullPath := filepath.Join(config.DataDir, fileName)
-	file, err := os.OpenFile(fullPath, os.O_CREATE|os.O_WRONLY, 0700)
+	file, err := os.OpenFile(fullPath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes https://github.com/optimism-java/shisui/issues/168

1. If flag ```--private.key``` is used, use the key received
2. Looks for file ```dataDir```/clientKey for a key, if find one, use it as private key
3. If can not find a key, creates a new one
4. Always writes the current key to the file ```dataDir```/clientKey